### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 React + RESAS API Codingtest
+![demo](https://user-images.githubusercontent.com/47209823/178140018-01cdba0c-01a9-4f58-ba2e-8e29b8aa62a0.gif)

--- a/vercel-ignore-build-step.sh
+++ b/vercel-ignore-build-step.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
+
+if [[ "$VERCEL_GIT_COMMIT_REF" == "main" ]] ; then
+  # Proceed with the build
+  echo "✅ - Build can proceed"
+  exit 1;
+
+else
+  # Don't build
+  echo "🛑 - Build cancelled"
+  exit 0;
+fi


### PR DESCRIPTION
Vercelのプレビューデプロイで特定のブランチ以外を無視する
ソースツリーからのプッシュが急に通らなくなったためテスト
OAuthトークン再読み込みで解決